### PR TITLE
Stop using quotation marks for syntax annotations

### DIFF
--- a/src/Chain_Selection_Density_Equivalence/Chains.thy
+++ b/src/Chain_Selection_Density_Equivalence/Chains.thy
@@ -95,8 +95,8 @@ fun induced_subchain :: "chain \<Rightarrow> slot_interval \<Rightarrow> chain" 
 | "induced_subchain \<C> (RightOpenInterval sl) = filter (\<lambda>B. bslot B \<ge> sl) \<C>"
 
 syntax
-  "_INDUCED_SUBCHAIN_CLOSED_INTERVAL" :: "chain \<Rightarrow> slot \<Rightarrow> slot \<Rightarrow> chain" ("_[_;_]" [70, 0, 0] 70)
-  "_INDUCED_SUBCHAIN_RIGHT_OPEN_INTERVAL" :: "chain \<Rightarrow> slot \<Rightarrow> slot \<Rightarrow> chain" ("_[_;] " [70, 0] 70)
+  "_INDUCED_SUBCHAIN_CLOSED_INTERVAL" :: "chain \<Rightarrow> slot \<Rightarrow> slot \<Rightarrow> chain" (\<open>_[_;_]\<close> [70, 0, 0] 70)
+  "_INDUCED_SUBCHAIN_RIGHT_OPEN_INTERVAL" :: "chain \<Rightarrow> slot \<Rightarrow> slot \<Rightarrow> chain" (\<open>_[_;] \<close> [70, 0] 70)
 
 translations
   "\<C>[sl\<^sub>1;sl\<^sub>2]" \<rightleftharpoons> "CONST induced_subchain \<C> (CONST ClosedInterval sl\<^sub>1 sl\<^sub>2)"

--- a/src/Chain_Selection_Density_Equivalence/Proof.thy
+++ b/src/Chain_Selection_Density_Equivalence/Proof.thy
@@ -830,10 +830,10 @@ interpretation test_protocol_parameters: protocol_parameters test_k test_f
   unfolding test_maxvalid_bg_def
   by unfold_locales simp_all
 
-abbreviation make_test_block :: "slot \<Rightarrow> block" ("B\<^bsub>_\<^esub>") where
+abbreviation make_test_block :: "slot \<Rightarrow> block" (\<open>B\<^bsub>_\<^esub>\<close>) where
   "B\<^bsub>sl\<^esub> \<equiv> (sl, ())"
 
-abbreviation make_test_chain :: "slot list \<Rightarrow> chain" ("\<langle>_\<rangle>") where
+abbreviation make_test_chain :: "slot list \<Rightarrow> chain" (\<open>\<langle>_\<rangle>\<close>) where
   "\<langle>ss\<rangle> \<equiv> map make_test_block ss"
 
 abbreviation test_equivalence where

--- a/src/Ouroboros_Praos_Implementation.thy
+++ b/src/Ouroboros_Praos_Implementation.thy
@@ -21,7 +21,7 @@ text \<open>
   security properties of the protocol. Thus, we model these ideal functionalities as locale's.
 \<close>
 
-no_notation Sublist.parallel (infixl "\<parallel>" 50)
+no_notation Sublist.parallel (infixl \<open>\<parallel>\<close> 50)
 
 subsection \<open> Preliminaries \<close>
 


### PR DESCRIPTION
This resolves #17.