### PR TITLE
Adapt heading to single-state-machine specification

### DIFF
--- a/src/Ouroboros-Mini_Protocols-Ping_Pong.thy
+++ b/src/Ouroboros-Mini_Protocols-Ping_Pong.thy
@@ -19,7 +19,7 @@ datatype party =
   Client |
   Server
 
-subsection \<open>State Machines\<close>
+subsection \<open>State Machine\<close>
 
 datatype state =
   Idle |

--- a/src/Ouroboros-Mini_Protocols-Request_Response.thy
+++ b/src/Ouroboros-Mini_Protocols-Request_Response.thy
@@ -23,7 +23,7 @@ datatype party =
   Client |
   Server
 
-subsection \<open>State Machines\<close>
+subsection \<open>State Machine\<close>
 
 datatype state =
   Idle |


### PR DESCRIPTION
This resolves #77.